### PR TITLE
Add EF Core PostgreSQL setup

### DIFF
--- a/LiteMoney.Api/LiteMoney.Api.csproj
+++ b/LiteMoney.Api/LiteMoney.Api.csproj
@@ -7,9 +7,14 @@
         <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
     </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
-    </ItemGroup>
+  <ItemGroup>
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.5"/>
+  </ItemGroup>
+
+  <ItemGroup>
+      <ProjectReference Include="..\LiteMoney.Infrastructure\LiteMoney.Infrastructure.csproj" />
+      <ProjectReference Include="..\LiteMoney.Application\LiteMoney.Application.csproj" />
+  </ItemGroup>
 
     <ItemGroup>
       <Content Include="..\.dockerignore">

--- a/LiteMoney.Api/Program.cs
+++ b/LiteMoney.Api/Program.cs
@@ -1,8 +1,16 @@
+using LiteMoney.Infrastructure.Data;
+using LiteMoney.Application.Interfaces;
+using LiteMoney.Infrastructure.Repositories;
+using Microsoft.EntityFrameworkCore;
+
 var builder = WebApplication.CreateBuilder(args);
 
 // Add services to the container.
 // Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
 builder.Services.AddOpenApi();
+builder.Services.AddDbContext<LiteMoney.Infrastructure.Data.LiteMoneyDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
+builder.Services.AddScoped(typeof(LiteMoney.Application.Interfaces.IRepository<>), typeof(LiteMoney.Infrastructure.Repositories.Repository<>));
 
 var app = builder.Build();
 

--- a/LiteMoney.Api/appsettings.Development.json
+++ b/LiteMoney.Api/appsettings.Development.json
@@ -4,5 +4,8 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=LiteMoneyDb;Username=postgres;Password=postgres"
   }
 }

--- a/LiteMoney.Api/appsettings.json
+++ b/LiteMoney.Api/appsettings.json
@@ -5,5 +5,8 @@
       "Microsoft.AspNetCore": "Warning"
     }
   },
-  "AllowedHosts": "*"
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "DefaultConnection": "Host=localhost;Port=5432;Database=LiteMoneyDb;Username=postgres;Password=postgres"
+  }
 }

--- a/LiteMoney.Application/Interfaces/IRepository.cs
+++ b/LiteMoney.Application/Interfaces/IRepository.cs
@@ -1,0 +1,13 @@
+using System.Linq.Expressions;
+
+namespace LiteMoney.Application.Interfaces;
+
+public interface IRepository<T> where T : class
+{
+    Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task AddAsync(T entity, CancellationToken cancellationToken = default);
+    void Update(T entity);
+    void Remove(T entity);
+    Task<int> SaveChangesAsync(CancellationToken cancellationToken = default);
+}

--- a/LiteMoney.Application/LiteMoney.Application.csproj
+++ b/LiteMoney.Application/LiteMoney.Application.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteMoney.Domain\LiteMoney.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/LiteMoney.Domain/LiteMoney.Domain.csproj
+++ b/LiteMoney.Domain/LiteMoney.Domain.csproj
@@ -1,0 +1,6 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>

--- a/LiteMoney.Domain/Models/User.cs
+++ b/LiteMoney.Domain/Models/User.cs
@@ -1,0 +1,7 @@
+namespace LiteMoney.Domain.Models;
+
+public class User
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+}

--- a/LiteMoney.Infrastructure/Data/LiteMoneyContextFactory.cs
+++ b/LiteMoney.Infrastructure/Data/LiteMoneyContextFactory.cs
@@ -1,0 +1,22 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Design;
+using Microsoft.Extensions.Configuration;
+
+namespace LiteMoney.Infrastructure.Data;
+
+public class LiteMoneyContextFactory : IDesignTimeDbContextFactory<LiteMoneyDbContext>
+{
+    public LiteMoneyDbContext CreateDbContext(string[] args)
+    {
+        var configuration = new ConfigurationBuilder()
+            .SetBasePath(Directory.GetCurrentDirectory())
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddEnvironmentVariables()
+            .Build();
+
+        var optionsBuilder = new DbContextOptionsBuilder<LiteMoneyDbContext>();
+        optionsBuilder.UseNpgsql(configuration.GetConnectionString("DefaultConnection"));
+
+        return new LiteMoneyDbContext(optionsBuilder.Options);
+    }
+}

--- a/LiteMoney.Infrastructure/Data/LiteMoneyDbContext.cs
+++ b/LiteMoney.Infrastructure/Data/LiteMoneyDbContext.cs
@@ -1,0 +1,18 @@
+using LiteMoney.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+
+namespace LiteMoney.Infrastructure.Data;
+
+public class LiteMoneyDbContext : DbContext
+{
+    public LiteMoneyDbContext(DbContextOptions<LiteMoneyDbContext> options) : base(options)
+    {
+    }
+
+    public DbSet<User> Users => Set<User>();
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/LiteMoney.Infrastructure/LiteMoney.Infrastructure.csproj
+++ b/LiteMoney.Infrastructure/LiteMoney.Infrastructure.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.0-preview.4.24266.7" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.0-preview.4" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.0-preview.4.24266.7" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\LiteMoney.Application\LiteMoney.Application.csproj" />
+    <ProjectReference Include="..\LiteMoney.Domain\LiteMoney.Domain.csproj" />
+  </ItemGroup>
+</Project>

--- a/LiteMoney.Infrastructure/Migrations/20240730000000_InitialCreate.cs
+++ b/LiteMoney.Infrastructure/Migrations/20240730000000_InitialCreate.cs
@@ -1,0 +1,32 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace LiteMoney.Infrastructure.Migrations
+{
+    public partial class InitialCreate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "Users",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    Name = table.Column<string>(type: "text", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_Users", x => x.Id);
+                });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "Users");
+        }
+    }
+}

--- a/LiteMoney.Infrastructure/Migrations/LiteMoneyDbContextModelSnapshot.cs
+++ b/LiteMoney.Infrastructure/Migrations/LiteMoneyDbContextModelSnapshot.cs
@@ -1,0 +1,41 @@
+using LiteMoney.Domain.Models;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace LiteMoney.Infrastructure.Migrations
+{
+    [DbContext(typeof(LiteMoney.Infrastructure.Data.LiteMoneyDbContext))]
+    partial class LiteMoneyDbContextModelSnapshot : ModelSnapshot
+    {
+        protected override void BuildModel(ModelBuilder modelBuilder)
+        {
+#pragma warning disable 612, 618
+            modelBuilder
+                .HasAnnotation("ProductVersion", "9.0.0-preview.4.24266.7")
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
+
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
+
+            modelBuilder.Entity("LiteMoney.Domain.Models.User", b =>
+                {
+                    b.Property<int>("Id")
+                        .ValueGeneratedOnAdd()
+                        .HasColumnType("integer")
+                        .HasAnnotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn);
+
+                    b.Property<string>("Name")
+                        .IsRequired()
+                        .HasColumnType("text");
+
+                    b.HasKey("Id");
+
+                    b.ToTable("Users");
+                });
+#pragma warning restore 612, 618
+        }
+    }
+}

--- a/LiteMoney.Infrastructure/Repositories/Repository.cs
+++ b/LiteMoney.Infrastructure/Repositories/Repository.cs
@@ -1,0 +1,33 @@
+using LiteMoney.Application.Interfaces;
+using LiteMoney.Infrastructure.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace LiteMoney.Infrastructure.Repositories;
+
+public class Repository<T> : IRepository<T> where T : class
+{
+    private readonly LiteMoneyDbContext _context;
+    private readonly DbSet<T> _dbSet;
+
+    public Repository(LiteMoneyDbContext context)
+    {
+        _context = context;
+        _dbSet = _context.Set<T>();
+    }
+
+    public async Task<T?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        => await _dbSet.FindAsync(new object?[] { id }, cancellationToken);
+
+    public async Task<IEnumerable<T>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await _dbSet.ToListAsync(cancellationToken);
+
+    public async Task AddAsync(T entity, CancellationToken cancellationToken = default)
+        => await _dbSet.AddAsync(entity, cancellationToken);
+
+    public void Update(T entity) => _dbSet.Update(entity);
+
+    public void Remove(T entity) => _dbSet.Remove(entity);
+
+    public async Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+        => await _context.SaveChangesAsync(cancellationToken);
+}

--- a/LiteMoney.sln
+++ b/LiteMoney.sln
@@ -7,15 +7,33 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		compose.yaml = compose.yaml
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteMoney.Domain", "LiteMoney.Domain\LiteMoney.Domain.csproj", "{1A1ACEE7-9E4E-4C6D-B138-17D955180C20}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteMoney.Application", "LiteMoney.Application\LiteMoney.Application.csproj", "{C5D62E3B-A4C4-4163-82D0-3D473E4C2F87}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "LiteMoney.Infrastructure", "LiteMoney.Infrastructure\LiteMoney.Infrastructure.csproj", "{13C63912-223D-42D7-957E-F6B9D42BFD72}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Release|Any CPU.Build.0 = Release|Any CPU
-	EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{AC08FB46-6A99-445B-892D-9CAEB1FDCBA0}.Release|Any CPU.Build.0 = Release|Any CPU
+{1A1ACEE7-9E4E-4C6D-B138-17D955180C20}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{1A1ACEE7-9E4E-4C6D-B138-17D955180C20}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{1A1ACEE7-9E4E-4C6D-B138-17D955180C20}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{1A1ACEE7-9E4E-4C6D-B138-17D955180C20}.Release|Any CPU.Build.0 = Release|Any CPU
+{C5D62E3B-A4C4-4163-82D0-3D473E4C2F87}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{C5D62E3B-A4C4-4163-82D0-3D473E4C2F87}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{C5D62E3B-A4C4-4163-82D0-3D473E4C2F87}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{C5D62E3B-A4C4-4163-82D0-3D473E4C2F87}.Release|Any CPU.Build.0 = Release|Any CPU
+{13C63912-223D-42D7-957E-F6B9D42BFD72}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{13C63912-223D-42D7-957E-F6B9D42BFD72}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{13C63912-223D-42D7-957E-F6B9D42BFD72}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{13C63912-223D-42D7-957E-F6B9D42BFD72}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- add Domain/Application/Infrastructure projects for clean architecture
- register DbContext and generic repository using EF Core
- add PostgreSQL connection strings
- include an initial migration template

## Testing
- `dotnet ef migrations add InitialCreate --project LiteMoney.Infrastructure --startup-project LiteMoney.Api` *(fails: command not found)*
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68898013889c8327a00a1cffac90b5df