### PR TITLE
Refactor infrastructure logic into application services

### DIFF
--- a/LiteMoney.Api/Program.cs
+++ b/LiteMoney.Api/Program.cs
@@ -1,5 +1,6 @@
 using LiteMoney.Infrastructure.Data;
 using LiteMoney.Application.Interfaces;
+using LiteMoney.Application.Services;
 using LiteMoney.Infrastructure.Repositories;
 using LiteMoney.Domain.Models;
 using LiteMoney.Infrastructure.GroupMaps;
@@ -14,6 +15,9 @@ builder.Services.AddOpenApi();
 builder.Services.AddDbContext<LiteMoneyDbContext>(options =>
     options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")));
 builder.Services.AddScoped(typeof(IRepository<>), typeof(Repository<>));
+builder.Services.AddScoped<IAccountService, AccountService>();
+builder.Services.AddScoped<ICategoryService, CategoryService>();
+builder.Services.AddScoped<ITransactionService, TransactionService>();
 builder.Services.AddIdentityCore<ApplicationUser>()
     .AddEntityFrameworkStores<LiteMoneyDbContext>();
 builder.Services.AddIdentityApiEndpoints<ApplicationUser>();

--- a/LiteMoney.Application/Services/AccountService.cs
+++ b/LiteMoney.Application/Services/AccountService.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Application.Interfaces;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public class AccountService : IAccountService
+{
+    private readonly IRepository<Account> _repository;
+
+    public AccountService(IRepository<Account> repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await _repository.GetAllAsync(cancellationToken);
+
+    public async Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        => await _repository.GetByIdAsync(id, cancellationToken);
+
+    public async Task<Account> CreateAsync(Account account, CancellationToken cancellationToken = default)
+    {
+        await _repository.AddAsync(account, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+        return account;
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _repository.GetByIdAsync(id, cancellationToken);
+        if (entity is null) return false;
+        _repository.Remove(entity);
+        await _repository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/LiteMoney.Application/Services/CategoryService.cs
+++ b/LiteMoney.Application/Services/CategoryService.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Application.Interfaces;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public class CategoryService : ICategoryService
+{
+    private readonly IRepository<Category> _repository;
+
+    public CategoryService(IRepository<Category> repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<IEnumerable<Category>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await _repository.GetAllAsync(cancellationToken);
+
+    public async Task<Category?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        => await _repository.GetByIdAsync(id, cancellationToken);
+
+    public async Task<Category> CreateAsync(Category category, CancellationToken cancellationToken = default)
+    {
+        await _repository.AddAsync(category, cancellationToken);
+        await _repository.SaveChangesAsync(cancellationToken);
+        return category;
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _repository.GetByIdAsync(id, cancellationToken);
+        if (entity is null) return false;
+        _repository.Remove(entity);
+        await _repository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/LiteMoney.Application/Services/IAccountService.cs
+++ b/LiteMoney.Application/Services/IAccountService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public interface IAccountService
+{
+    Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Account> CreateAsync(Account account, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/LiteMoney.Application/Services/ICategoryService.cs
+++ b/LiteMoney.Application/Services/ICategoryService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public interface ICategoryService
+{
+    Task<IEnumerable<Category>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<Category?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Category> CreateAsync(Category category, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/LiteMoney.Application/Services/ITransactionService.cs
+++ b/LiteMoney.Application/Services/ITransactionService.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public interface ITransactionService
+{
+    Task<IEnumerable<Transaction>> GetAllAsync(CancellationToken cancellationToken = default);
+    Task<Transaction?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
+    Task<Transaction?> CreateAsync(Transaction transaction, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+}

--- a/LiteMoney.Application/Services/TransactionService.cs
+++ b/LiteMoney.Application/Services/TransactionService.cs
@@ -1,0 +1,71 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using LiteMoney.Application.Interfaces;
+using LiteMoney.Domain.Models;
+
+namespace LiteMoney.Application.Services;
+
+public class TransactionService : ITransactionService
+{
+    private readonly IRepository<Transaction> _transactionRepository;
+    private readonly IRepository<Account> _accountRepository;
+    private readonly IRepository<Category> _categoryRepository;
+
+    public TransactionService(
+        IRepository<Transaction> transactionRepository,
+        IRepository<Account> accountRepository,
+        IRepository<Category> categoryRepository)
+    {
+        _transactionRepository = transactionRepository;
+        _accountRepository = accountRepository;
+        _categoryRepository = categoryRepository;
+    }
+
+    public async Task<IEnumerable<Transaction>> GetAllAsync(CancellationToken cancellationToken = default)
+        => await _transactionRepository.GetAllAsync(cancellationToken);
+
+    public async Task<Transaction?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
+        => await _transactionRepository.GetByIdAsync(id, cancellationToken);
+
+    public async Task<Transaction?> CreateAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        var account = await _accountRepository.GetByIdAsync(transaction.AccountId, cancellationToken);
+        var category = await _categoryRepository.GetByIdAsync(transaction.CategoryId, cancellationToken);
+        if (account is null || category is null)
+            return null;
+
+        await _transactionRepository.AddAsync(transaction, cancellationToken);
+
+        account.Balance += category.Type == CategoryType.Expense
+            ? -transaction.Amount
+            : transaction.Amount;
+
+        _accountRepository.Update(account);
+
+        await _transactionRepository.SaveChangesAsync(cancellationToken);
+        return transaction;
+    }
+
+    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    {
+        var transaction = await _transactionRepository.GetByIdAsync(id, cancellationToken);
+        if (transaction is null) return false;
+
+        var account = await _accountRepository.GetByIdAsync(transaction.AccountId, cancellationToken);
+        var category = await _categoryRepository.GetByIdAsync(transaction.CategoryId, cancellationToken);
+        if (account is null || category is null)
+            return false;
+
+        _transactionRepository.Remove(transaction);
+
+        account.Balance += category.Type == CategoryType.Expense
+            ? transaction.Amount
+            : -transaction.Amount;
+
+        _accountRepository.Update(account);
+
+        await _transactionRepository.SaveChangesAsync(cancellationToken);
+        return true;
+    }
+}

--- a/LiteMoney.Infrastructure/GroupMaps/AccountGroupMap.cs
+++ b/LiteMoney.Infrastructure/GroupMaps/AccountGroupMap.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using LiteMoney.Application.Interfaces;
+using LiteMoney.Application.Services;
 using LiteMoney.Domain.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -12,28 +13,23 @@ public class AccountGroupMap : IEndpointGroup
     {
         var group = app.MapGroup("/accounts");
 
-        group.MapGet("/", async (IRepository<Account> repo, CancellationToken ct) =>
-            Results.Ok(await repo.GetAllAsync(ct)));
+        group.MapGet("/", async (IAccountService service, CancellationToken ct) =>
+            Results.Ok(await service.GetAllAsync(ct)));
 
-        group.MapGet("/{id:int}", async (int id, IRepository<Account> repo, CancellationToken ct) =>
-            await repo.GetByIdAsync(id, ct) is Account account
+        group.MapGet("/{id:int}", async (int id, IAccountService service, CancellationToken ct) =>
+            await service.GetByIdAsync(id, ct) is Account account
                 ? Results.Ok(account)
                 : Results.NotFound());
 
-        group.MapPost("/", async (Account account, IRepository<Account> repo, CancellationToken ct) =>
+        group.MapPost("/", async (Account account, IAccountService service, CancellationToken ct) =>
         {
-            await repo.AddAsync(account, ct);
-            await repo.SaveChangesAsync(ct);
-            return Results.Created($"/accounts/{account.Id}", account);
+            var created = await service.CreateAsync(account, ct);
+            return Results.Created($"/accounts/{created.Id}", created);
         });
 
-        group.MapDelete("/{id:int}", async (int id, IRepository<Account> repo, CancellationToken ct) =>
-        {
-            var account = await repo.GetByIdAsync(id, ct);
-            if (account is null) return Results.NotFound();
-            repo.Remove(account);
-            await repo.SaveChangesAsync(ct);
-            return Results.NoContent();
-        });
+        group.MapDelete("/{id:int}", async (int id, IAccountService service, CancellationToken ct) =>
+            await service.DeleteAsync(id, ct)
+                ? Results.NoContent()
+                : Results.NotFound());
     }
 }

--- a/LiteMoney.Infrastructure/GroupMaps/CategoryGroupMap.cs
+++ b/LiteMoney.Infrastructure/GroupMaps/CategoryGroupMap.cs
@@ -1,5 +1,6 @@
 using System.Threading;
 using LiteMoney.Application.Interfaces;
+using LiteMoney.Application.Services;
 using LiteMoney.Domain.Models;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
@@ -12,28 +13,23 @@ public class CategoryGroupMap : IEndpointGroup
     {
         var group = app.MapGroup("/categories");
 
-        group.MapGet("/", async (IRepository<Category> repo, CancellationToken ct) =>
-            Results.Ok(await repo.GetAllAsync(ct)));
+        group.MapGet("/", async (ICategoryService service, CancellationToken ct) =>
+            Results.Ok(await service.GetAllAsync(ct)));
 
-        group.MapGet("/{id:int}", async (int id, IRepository<Category> repo, CancellationToken ct) =>
-            await repo.GetByIdAsync(id, ct) is Category category
+        group.MapGet("/{id:int}", async (int id, ICategoryService service, CancellationToken ct) =>
+            await service.GetByIdAsync(id, ct) is Category category
                 ? Results.Ok(category)
                 : Results.NotFound());
 
-        group.MapPost("/", async (Category category, IRepository<Category> repo, CancellationToken ct) =>
+        group.MapPost("/", async (Category category, ICategoryService service, CancellationToken ct) =>
         {
-            await repo.AddAsync(category, ct);
-            await repo.SaveChangesAsync(ct);
-            return Results.Created($"/categories/{category.Id}", category);
+            var created = await service.CreateAsync(category, ct);
+            return Results.Created($"/categories/{created.Id}", created);
         });
 
-        group.MapDelete("/{id:int}", async (int id, IRepository<Category> repo, CancellationToken ct) =>
-        {
-            var category = await repo.GetByIdAsync(id, ct);
-            if (category is null) return Results.NotFound();
-            repo.Remove(category);
-            await repo.SaveChangesAsync(ct);
-            return Results.NoContent();
-        });
+        group.MapDelete("/{id:int}", async (int id, ICategoryService service, CancellationToken ct) =>
+            await service.DeleteAsync(id, ct)
+                ? Results.NoContent()
+                : Results.NotFound());
     }
 }


### PR DESCRIPTION
## Summary
- move domain logic from group maps into Application services
- call new services from infrastructure group maps
- register application services in API DI setup

## Testing
- `dotnet build LiteMoney.sln -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688cf276ddf483279828e895522157fa