### PR TITLE
Add currency endpoint and simplify account currency

### DIFF
--- a/LiteMoney.Domain/Models/Account.cs
+++ b/LiteMoney.Domain/Models/Account.cs
@@ -5,9 +5,7 @@ public class Account
     public int Id { get; set; }
     public string Name { get; set; } = string.Empty;
     public decimal Balance { get; set; }
-
-    public int CurrencyId { get; set; }
-    public Currency Currency { get; set; } = null!;
+    public required string NameCurrency { get; set; }
 
     public string UserId { get; set; } = string.Empty;
     public ApplicationUser User { get; set; } = null!;

--- a/LiteMoney.Infrastructure/GroupMaps/CurrencyGroupMap.cs
+++ b/LiteMoney.Infrastructure/GroupMaps/CurrencyGroupMap.cs
@@ -1,0 +1,26 @@
+using System.Linq;
+using LiteMoney.Application.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Nager.Country;
+
+namespace LiteMoney.Infrastructure.GroupMaps;
+
+public class CurrencyGroupMap : IEndpointGroup
+{
+    public void Map(WebApplication app)
+    {
+        var group = app.MapGroup("/currencies");
+
+        group.MapGet("/", () =>
+        {
+            var provider = new CountryProvider();
+            var currencies = provider.GetCountries()
+                .SelectMany(c => c.Currencies)
+                .GroupBy(c => c.ISO4217Code)
+                .Select(g => new { Code = g.Key, Name = g.First().Name })
+                .OrderBy(x => x.Code)
+                .ToList();
+            return Results.Ok(currencies);
+        });
+    }
+}

--- a/LiteMoney.Infrastructure/LiteMoney.Infrastructure.csproj
+++ b/LiteMoney.Infrastructure/LiteMoney.Infrastructure.csproj
@@ -11,6 +11,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="9.0.7" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageReference Include="Nager.Country" Version="2.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary
- add Nager.Country package and expose `/currencies` endpoint listing currency codes and names
- simplify Account model by replacing Currency reference with required NameCurrency field

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688eb86d37008327b73217d6b0493f1a