### PR TITLE
Restrict account endpoints to authenticated user

### DIFF
--- a/LiteMoney.Application/Services/AccountService.cs
+++ b/LiteMoney.Application/Services/AccountService.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
+using System.Linq;
 using LiteMoney.Application.Interfaces;
 using LiteMoney.Domain.Models;
 
@@ -15,23 +16,41 @@ public class AccountService : IAccountService
         _repository = repository;
     }
 
-    public async Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken = default)
-        => await _repository.GetAllAsync(cancellationToken);
+    public async Task<IEnumerable<Account>> GetAllAsync(string userId, CancellationToken cancellationToken = default)
+        => (await _repository.GetAllAsync(cancellationToken)).Where(a => a.UserId == userId);
 
-    public async Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken = default)
-        => await _repository.GetByIdAsync(id, cancellationToken);
-
-    public async Task<Account> CreateAsync(Account account, CancellationToken cancellationToken = default)
+    public async Task<Account?> GetByIdAsync(int id, string userId, CancellationToken cancellationToken = default)
     {
+        var account = await _repository.GetByIdAsync(id, cancellationToken);
+        return account?.UserId == userId ? account : null;
+    }
+
+    public async Task<Account> CreateAsync(Account account, string userId, CancellationToken cancellationToken = default)
+    {
+        account.UserId = userId;
         await _repository.AddAsync(account, cancellationToken);
         await _repository.SaveChangesAsync(cancellationToken);
         return account;
     }
 
-    public async Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default)
+    public async Task<Account?> UpdateAsync(Account account, string userId, CancellationToken cancellationToken = default)
+    {
+        var entity = await _repository.GetByIdAsync(account.Id, cancellationToken);
+        if (entity is null || entity.UserId != userId) return null;
+
+        entity.Name = account.Name;
+        entity.Balance = account.Balance;
+        entity.NameCurrency = account.NameCurrency;
+
+        _repository.Update(entity);
+        await _repository.SaveChangesAsync(cancellationToken);
+        return entity;
+    }
+
+    public async Task<bool> DeleteAsync(int id, string userId, CancellationToken cancellationToken = default)
     {
         var entity = await _repository.GetByIdAsync(id, cancellationToken);
-        if (entity is null) return false;
+        if (entity is null || entity.UserId != userId) return false;
         _repository.Remove(entity);
         await _repository.SaveChangesAsync(cancellationToken);
         return true;

--- a/LiteMoney.Application/Services/IAccountService.cs
+++ b/LiteMoney.Application/Services/IAccountService.cs
@@ -7,8 +7,9 @@ namespace LiteMoney.Application.Services;
 
 public interface IAccountService
 {
-    Task<IEnumerable<Account>> GetAllAsync(CancellationToken cancellationToken = default);
-    Task<Account?> GetByIdAsync(int id, CancellationToken cancellationToken = default);
-    Task<Account> CreateAsync(Account account, CancellationToken cancellationToken = default);
-    Task<bool> DeleteAsync(int id, CancellationToken cancellationToken = default);
+    Task<IEnumerable<Account>> GetAllAsync(string userId, CancellationToken cancellationToken = default);
+    Task<Account?> GetByIdAsync(int id, string userId, CancellationToken cancellationToken = default);
+    Task<Account> CreateAsync(Account account, string userId, CancellationToken cancellationToken = default);
+    Task<Account?> UpdateAsync(Account account, string userId, CancellationToken cancellationToken = default);
+    Task<bool> DeleteAsync(int id, string userId, CancellationToken cancellationToken = default);
 }

--- a/LiteMoney.Infrastructure/GroupMaps/AccountGroupMap.cs
+++ b/LiteMoney.Infrastructure/GroupMaps/AccountGroupMap.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using System.Threading;
 using LiteMoney.Application.Interfaces;
 using LiteMoney.Application.Services;
@@ -11,25 +12,52 @@ public class AccountGroupMap : IEndpointGroup
 {
     public void Map(WebApplication app)
     {
-        var group = app.MapGroup("/accounts");
+        var group = app.MapGroup("/accounts").RequireAuthorization();
 
-        group.MapGet("/", async (IAccountService service, CancellationToken ct) =>
-            Results.Ok(await service.GetAllAsync(ct)));
-
-        group.MapGet("/{id:int}", async (int id, IAccountService service, CancellationToken ct) =>
-            await service.GetByIdAsync(id, ct) is Account account
-                ? Results.Ok(account)
-                : Results.NotFound());
-
-        group.MapPost("/", async (Account account, IAccountService service, CancellationToken ct) =>
+        group.MapGet("/", async (ClaimsPrincipal principal, IAccountService service, CancellationToken ct) =>
         {
-            var created = await service.CreateAsync(account, ct);
+            var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is null) return Results.Unauthorized();
+
+            return Results.Ok(await service.GetAllAsync(userId, ct));
+        });
+
+        group.MapGet("/{id:int}", async (int id, ClaimsPrincipal principal, IAccountService service, CancellationToken ct) =>
+        {
+            var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is null) return Results.Unauthorized();
+
+            var account = await service.GetByIdAsync(id, userId, ct);
+            return account is null ? Results.NotFound() : Results.Ok(account);
+        });
+
+        group.MapPost("/", async (Account account, ClaimsPrincipal principal, IAccountService service, CancellationToken ct) =>
+        {
+            var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is null) return Results.Unauthorized();
+
+            var created = await service.CreateAsync(account, userId, ct);
             return Results.Created($"/accounts/{created.Id}", created);
         });
 
-        group.MapDelete("/{id:int}", async (int id, IAccountService service, CancellationToken ct) =>
-            await service.DeleteAsync(id, ct)
+        group.MapPut("/{id:int}", async (int id, Account account, ClaimsPrincipal principal, IAccountService service, CancellationToken ct) =>
+        {
+            var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is null) return Results.Unauthorized();
+
+            account.Id = id;
+            var updated = await service.UpdateAsync(account, userId, ct);
+            return updated is null ? Results.NotFound() : Results.Ok(updated);
+        });
+
+        group.MapDelete("/{id:int}", async (int id, ClaimsPrincipal principal, IAccountService service, CancellationToken ct) =>
+        {
+            var userId = principal.FindFirstValue(ClaimTypes.NameIdentifier);
+            if (userId is null) return Results.Unauthorized();
+
+            return await service.DeleteAsync(id, userId, ct)
                 ? Results.NoContent()
-                : Results.NotFound());
+                : Results.NotFound();
+        });
     }
 }


### PR DESCRIPTION
## Summary
- require authorization for account endpoints and include PUT for updates
- scope account service operations to the authenticated user
- add update method to account service implementation

## Testing
- `dotnet build` *(fails: command not found)*
- `apt-get update` *(fails: repository is not signed)*
- `curl -L https://dot.net/v1/dotnet-install.sh` *(fails: CONNECT tunnel failed, response 403)*

------
https://chatgpt.com/codex/tasks/task_e_68925f71756883279c10411d6db7e2ba